### PR TITLE
[160] Add missing env var `OWNER_ID` in the example `docker-compose`

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ services:
     restart: on-failure
     environment:
       TOKEN: ${TOKEN}
+      OWNER_ID: ${OWNER_ID}
       POSTGRES_USER: ${POSTGRES_USER}
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
       POSTGRES_URL: ${POSTGRES_URL}


### PR DESCRIPTION
Adds the missing env var