### PR TITLE
[162] Change fallback value of alpagotchi image

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ services:
         
   bot:
     container_name: bot
-    image: alpagotchi/discord-bot:${ALPAGOTCHI_VERSION:-0.3.3}
+    image: alpagotchi/discord-bot:${ALPAGOTCHI_VERSION:-0.0.1}
     depends_on:
       - database
     restart: on-failure


### PR DESCRIPTION
Change the fallback value of the Alpagotchi to 0.0.1 which is the most recent version on dockerhub