### PR TITLE
chore: remove GH dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,0 @@
-version: 2
-updates:
-  - package-ecosystem: "maven"
-    directory: "/"
-    schedule:
-      interval: "monthly"
-      day: "sunday"


### PR DESCRIPTION
This PR removes the config file for GH dependabot