### PR TITLE
feat: update dependencies to their latest version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.12.1</version>
+                <version>3.14.1</version>
                 <configuration>
                     <source>21</source>
                     <target>21</target>
@@ -26,7 +26,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-assembly-plugin</artifactId>
-                <version>3.7.1</version>
+                <version>3.8.0</version>
                 <configuration>
                     <descriptorRefs>
                         <descriptorRef>jar-with-dependencies</descriptorRef>
@@ -54,12 +54,12 @@
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
-            <version>1.5.6</version>
+            <version>1.5.34</version>
         </dependency>
         <dependency>
             <groupId>net.dv8tion</groupId>
             <artifactId>JDA</artifactId>
-            <version>5.0.0-beta.24</version>
+            <version>6.4.2</version>
         </dependency>
         <dependency>
             <groupId>com.jakewharton.fliptables</groupId>
@@ -69,17 +69,17 @@
         <dependency>
             <groupId>org.postgresql</groupId>
             <artifactId>postgresql</artifactId>
-            <version>42.7.3</version>
+            <version>42.7.11</version>
         </dependency>
         <dependency>
             <groupId>org.hibernate.orm</groupId>
             <artifactId>hibernate-core</artifactId>
-            <version>6.4.4.Final</version>
+            <version>7.4.0.Final</version>
         </dependency>
         <dependency>
             <groupId>org.hibernate.orm</groupId>
             <artifactId>hibernate-hikaricp</artifactId>
-            <version>6.4.4.Final</version>
+            <version>7.4.0.Final</version>
         </dependency>
     </dependencies>
 </project>


### PR DESCRIPTION
This PR updates the dependencies to their latest versions:

| Dependency | Old Version | New Version |
| -- | -- | -- |
| `maven-compiler-plugin` | 3.12.1 | 3.14.1 |
| `maven-assembly-plugin` | 3.7.1 | 3.8.0 |
| `logback-classic` | 1.5.6 | 1.5.34 |
| `JDA` | 5.0.0-beta.24 | 6.4.2 |
| `postgresql` | 42.7.3 | 42.7.11 |
| `hibernate-core` | 6.4.4.Final | 7.4.0.Final |
| `hibernate-hikaricp` | 6.4.4.Final | 7.4.0.Final |