### PR TITLE
fix: update deprecated base images and restructure file

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,24 +1,17 @@
-FROM maven:3.9.5 AS build
-ENV HOME=/home/app
-RUN mkdir -p $HOME
-WORKDIR $HOME
-ADD pom.xml $HOME
+FROM maven:3.9 AS build
+
+WORKDIR /home/app
+
+COPY pom.xml .
 RUN mvn verify
-ADD src $HOME/src
+
+COPY src src
 RUN mvn package
 
-FROM openjdk:21
-ENV HOME=/home/app
-WORKDIR $HOME
-ARG TOKEN=""
-ENV TOKEN=$TOKEN
-ARG POSTGRES_USER=""
-ENV POSTGRES_USER=$POSTGRES_USER
-ARG POSTGRES_PASSWORD=""
-ENV POSTGRES_PASSWORD=$POSTGRES_PASSWORD
-ARG POSTGRES_URL=""
-ENV POSTGRES_URL=$POSTGRES_URL
-ARG OWNER_ID=""
-ENV OWNER_ID=$OWNER_ID
-COPY --from=build $HOME/target/Alpagotchi-jar-with-dependencies.jar alpagotchi.jar
-CMD java -jar alpagotchi.jar
+FROM eclipse-temurin:21-jre-alpine
+
+WORKDIR /home/app
+
+COPY --from=build /home/app/target/Alpagotchi-jar-with-dependencies.jar alpagotchi.jar
+
+ENTRYPOINT [ "java", "-jar", "alpagotchi.jar" ]


### PR DESCRIPTION
This PR completely overhauls the current `Dockerfile`:

- Updates base images to their latest version (and replaces `openjdk` with `eclipse-temurin` since the former is deprecated)
- Removes unnecessary `ENV` and `ARG` instructions
- Replaces `ADD` by `COPY`
- Simplify specified pathes (since WORKDIR already contains the right path)