### PR TITLE
feat: replace `source` and `target` config with `release`

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,8 +19,7 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.14.1</version>
                 <configuration>
-                    <source>21</source>
-                    <target>21</target>
+                    <release>21</release>
                 </configuration>
             </plugin>
             <plugin>


### PR DESCRIPTION
This PR replaces the configuration of `source` and `target` with `release`.
The explanation of this can be found here: https://maven.apache.org/plugins/maven-compiler-plugin/examples/set-compiler-release.html

The relevant part is this behaviour:
> The --release option ensures that the code is compiled following the rules of the programming language of the specified release, and that generated classes target the release as well as the public API of that release. This means that, unlike the old [-source and -target options](https://maven.apache.org/plugins/maven-compiler-plugin/examples/set-compiler-source-and-target.html), the compiler will detect and generate an error when using APIs that don't exist in previous releases of Java SE